### PR TITLE
Default PREFIX value in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# PREFIX is the install location. Defaults to cwd.
+# PREFIX = /usr/local/bin
+PREFIX ?= .
+
 # These two definitions are used if you 'make install'
 # the value of LIBDIR should be the same as OMEGALIB in defs.h
 BINDIR = ${PREFIX}/bin

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,16 @@ LIBDIR = ${PREFIX}/share/omega
 # it will fail if none of them are defined.  If you do uncomment
 # one, make sure you comment out the other definition of CFLAGS lower down
 
-CFLAGS += -O2 -pipe -Wno-return-type -fstack-protector-strong -fno-strict-aliasing  -DBSD -DOMEGALIB=\"${LIBDIR}/\"  -Wl,-rpath=/usr/local/lib
+CFLAGS += \
+  -O2 \
+  -pipe \
+  -Wno-return-type \
+  -fstack-protector-strong \
+  -fno-strict-aliasing  \
+  -DBSD \
+  -DOMEGALIB=\"${LIBDIR}/\"  \
+  -Wl,-rpath=/usr/local/lib
+
 #CFLAGS = -DSYSV -O
 # I also had to define -cckr (K&R style C) for system V
 #CFLAGS = -DMSDOS -O


### PR DESCRIPTION
Defaults PREFIX to "." if otherwise not set in Env or Makefile. Split CFLAGS line.